### PR TITLE
Modified etils version to satisfy tensorflow_dataset version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
 dependencies = [
     "bitsandbytes==0.45.0",
     "einops",
+    "etils==1.5.1",
     "gsutil>=5.32",
     "hydra-core",
     "imageio",


### PR DESCRIPTION
When we use `uv sync`, uv will find the latest version of etils, which conflicts with the required version of tensorflow_datasets (4.9.2). The error message I met is:

```
File "/.../.venv/lib/python3.10/site-packages/tensorflow_datasets/core/dataset_builder.py", line 304, in code_path
    if isinstance(path, epath.resource_utils.ResourcePath) or path.parts:
AttributeError: 'MultiplexedPath' object has no attribute 'parts'
```

Changing the etils version to 1.5.1 solves this problem.